### PR TITLE
[Fix] overwrite of optional attributes with VersionString

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/ConfigItemAdd.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/ConfigItemAdd.pm
@@ -199,7 +199,7 @@ sub Run {
 
     for my $OptionalAttribute ( qw/Name Number VersionString/ ) {
         if ( $Param{Config}{ $OptionalAttribute } ) {
-            $ConfigItemParam{Name} = $Param{Config}{ $OptionalAttribute };
+            $ConfigItemParam{$OptionalAttribute} = $Param{Config}{ $OptionalAttribute };
         }
     }
 


### PR DESCRIPTION
Fix the overwrite of optional attributes for Transition Action ConfigItemAdd with VersionString for Version 11.1