### PR TITLE
[fix] Name and Number overwritten by VersionString

### DIFF
--- a/Kernel/System/ProcessManagement/TransitionAction/ConfigItemAdd.pm
+++ b/Kernel/System/ProcessManagement/TransitionAction/ConfigItemAdd.pm
@@ -199,7 +199,7 @@ sub Run {
 
     for my $OptionalAttribute ( qw/Name Number VersionString/ ) {
         if ( $Param{Config}{ $OptionalAttribute } ) {
-            $ConfigItemParam{Name} = $Param{Config}{ $OptionalAttribute };
+            $ConfigItemParam{$OptionalAttribute} = $Param{Config}{ $OptionalAttribute };
         }
     }
 


### PR DESCRIPTION
In ConfigItemAdd.pm VersionString and Number overwrite Name and VersionString and Number do not get set, because the loop does not change the Item and leaves it on Name. For Version 11.0